### PR TITLE
Update Spring Boot version to 3.4.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.4.7</version>
+        <version>3.4.8</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <groupId>com.pasadita</groupId>


### PR DESCRIPTION
## Changes
- Updated `Spring Boot` version to `3.4.8` in `pom.xml`.

## Why
- To stay up-to-date with the latest features, improvements, and bug fixes.

## Checklist
- [ ] Tests added/updated
- [ ] Documentation updated
- [ ] Version number increased (if applicable)