### PR TITLE
Update Spring Boot to version 3.5.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.4.8</version>
+        <version>3.5.5</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <groupId>com.pasadita</groupId>


### PR DESCRIPTION
This pull request updates the Spring Boot version to 3.5.5 in the `pom.xml` file to ensure compatibility and include the latest improvements and bug fixes.